### PR TITLE
Fix WhatsApp redirect for pages API

### DIFF
--- a/api/callback.js
+++ b/api/callback.js
@@ -11,6 +11,7 @@ export default async function handler(req, res) {
   if (!code || !whatsapp) {
     return res.status(400).json({ error: "Missing code or invalid WhatsApp number" });
   }
+  const phoneOnly = whatsapp.startsWith('+') ? whatsapp.slice(1) : whatsapp;
 
   const client_id = process.env.WHOOP_CLIENT_ID;
   const client_secret = process.env.WHOOP_CLIENT_SECRET;
@@ -57,7 +58,7 @@ export default async function handler(req, res) {
     await mongoClient.close();
 
     // Redirect back to WhatsApp chat
-    res.redirect("https://wa.me/" + encodeURIComponent(whatsapp));
+    res.redirect(`https://wa.me/${phoneOnly}`);
   } catch (err) {
     console.error("OAuth callback failed:", err);
     res.status(500).json({ error: "OAuth callback failed", debug: err.message });

--- a/pages/api/callback.js
+++ b/pages/api/callback.js
@@ -10,6 +10,7 @@ export default async function handler(req, res) {
   // Extract phone number from state (format: "whatsapp=+316xxxxxxx")
   const params = new URLSearchParams(state);
   const whatsapp = params.get('whatsapp');
+  const phoneOnly = whatsapp && whatsapp.startsWith('+') ? whatsapp.slice(1) : whatsapp;
 
   if (!whatsapp) {
     return res.status(400).json({ error: 'Missing WhatsApp number' });
@@ -39,7 +40,8 @@ export default async function handler(req, res) {
     // Save token for this user
     await storeTokenForUser(whatsapp, tokenData);
 
-    res.status(200).json({ success: true });
+    // Redirect back to WhatsApp chat
+    res.redirect(`https://wa.me/${phoneOnly}`);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Callback handler error' });


### PR DESCRIPTION
## Summary
- strip leading plus from phone in `pages/api/callback`
- redirect back to WhatsApp chat after login

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c1c42698c83299cef4f46328d002f