### PR TITLE
Remove node-fetch imports

### DIFF
--- a/api/body.js
+++ b/api/body.js
@@ -1,5 +1,4 @@
 import { MongoClient } from 'mongodb';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   try {

--- a/api/callback.js
+++ b/api/callback.js
@@ -1,7 +1,6 @@
 // /api/callback.js
 
 import { MongoClient } from 'mongodb';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   const code = req.query.code;

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,5 +1,4 @@
 import { MongoClient } from 'mongodb';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   try {

--- a/api/recovery.js
+++ b/api/recovery.js
@@ -1,5 +1,4 @@
 import { MongoClient } from 'mongodb';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   try {

--- a/api/sleep.js
+++ b/api/sleep.js
@@ -1,5 +1,4 @@
 import { MongoClient } from 'mongodb';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   try {

--- a/api/summary.js
+++ b/api/summary.js
@@ -1,5 +1,4 @@
 import { MongoClient } from 'mongodb';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   try {

--- a/api/whatsapp.js
+++ b/api/whatsapp.js
@@ -1,7 +1,6 @@
 import { MongoClient } from 'mongodb';
 import { OpenAI } from 'openai';
 import Twilio from 'twilio';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   try {

--- a/api/workout.js
+++ b/api/workout.js
@@ -1,5 +1,4 @@
 import { MongoClient } from 'mongodb';
-import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
   try {


### PR DESCRIPTION
## Summary
- drop explicit `node-fetch` import
- rely on the built-in `fetch` available in Node

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c29464ccc8329ba62e05494e96073