### PR TITLE
Fix login page redirect logic

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -12,13 +12,11 @@ export default function Login() {
 
   useEffect(() => {
     if (whatsapp) {
-      fetch(`/api/login?whatsapp=${encodeURIComponent(whatsapp)}`)
-        .then(res => res.json())
-        .then(data => {
-          if (data.url) {
-            window.location.href = data.url;
-          }
-        });
+      // The /api/login endpoint responds with an HTTP redirect. The previous
+      // implementation attempted to `fetch` the endpoint and parse JSON, which
+      // fails because the response body is empty. Instead, directly navigate the
+      // browser to the API route so the redirect is handled natively.
+      window.location.href = `/api/login?whatsapp=${encodeURIComponent(whatsapp)}`;
     }
   }, [whatsapp]);
 


### PR DESCRIPTION
## Summary
- fix login page: use direct navigation instead of fetch for /api/login

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c16d05d8483299377ff99070b1c49